### PR TITLE
Updated for speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # modwtpy
-Forked from main and rewritten loop to list compr. for speed.
-
-Aske L. Ejdrup, 2022.
+Forked from main and rewritten loop to list compr. for speed by Aske Ejdrup, 2022.
 
 modwt in python
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # modwtpy
 Forked from main and rewritten loop to list compr. for speed.
+
 Aske L. Ejdrup, 2022.
 
 modwt in python

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # modwtpy
+Forked from main and rewritten loop to list compr. for speed.
+Aske L. Ejdrup, 2022.
+
 modwt in python
 
 find the detail from the matlab Documentation:

--- a/modwt.py
+++ b/modwt.py
@@ -32,11 +32,7 @@ def circular_convolve_mra(h_j_o, w_j):
     ''' calculate the mra D_j'''
     N = len(w_j)
     l = np.arange(N)
-    D_j = np.zeros(N)
-    for t in range(N):
-        index = np.mod(t + l, N)
-        w_j_p = np.array([w_j[ind] for ind in index])
-        D_j[t] = (np.array(h_j_o) * w_j_p).sum()
+    D_j = [(h_j_o * w_j[np.mod(t + l, N)]).sum() for t in range(N)]
     return D_j
 
 


### PR DESCRIPTION
I've changed the circular_convolve_mra() function called in modwtmra() to a list comprehension, speeding it up significantly. For times series longer than 100k observations it was too slow for any real use, but the wait is manageable now.
